### PR TITLE
Add contains method to Collection class and related tests

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -852,4 +852,22 @@ class Collection implements ArrayAccess
     {
         array_walk_recursive($this->items, $callback, $arg);
     }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function contains(mixed $value): bool
+    {
+        foreach ($this->items as $item) {
+            if (is_object($item) && is_object($value)) {
+                if ($item == $value) {
+                    return true;
+                }
+            } elseif ($item === $value) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -859,15 +859,6 @@ class Collection implements ArrayAccess
      */
     public function contains(mixed $value): bool
     {
-        foreach ($this->items as $item) {
-            if (is_object($item) && is_object($value)) {
-                if ($item == $value) {
-                    return true;
-                }
-            } elseif ($item === $value) {
-                return true;
-            }
-        }
-        return false;
+        return in_array($value, $this->items, true);
     }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -608,4 +608,20 @@ class CollectionTest extends TestCase
         $collection->walkRecursive(fn(&$item) => $item *= 2);
         $this->assertEquals(['a' => 2, 'b' => ['x' => 4]], $collection->items());
     }
+
+    public function testContainsWithStringValues(): void
+    {
+        $collection = new Collection(['apple', 'banana', 'cherry']);
+        $this->assertTrue($collection->contains('banana'));
+        $this->assertFalse($collection->contains('grape'));
+    }
+
+    public function testContainsWithObjectValues(): void
+    {
+        $object1 = (object)['id' => 1, 'name' => 'John'];
+        $object2 = (object)['id' => 2, 'name' => 'Jane'];
+        $collection = new Collection([$object1, $object2]);
+        $this->assertTrue($collection->contains($object1));
+        $this->assertFalse($collection->contains((object)['id' => 3, 'name' => 'Doe']));
+    }
 }


### PR DESCRIPTION
Add `contains` method to `Collection` class and related tests.

* **Collection Class**:
  - Add `contains` method to check if a value exists in the collection.
  - Implement `contains` method to handle both string and object values.

* **CollectionTest Class**:
  - Add test for `contains` method with string values.
  - Add test for `contains` method with object values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mulertech/collections/pull/2?shareId=045f0f6b-b78b-472a-9599-f2340d78429b).